### PR TITLE
Ie11 compatibility fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -124,7 +124,7 @@ module.exports = function(m) {
 
     if (fast) {
         return Buffer.from(arr).toString('hex')
-	}
+    }
 
     return arr.map(function(i) { return i.toString(16).padStart(2, '0') }).join('')
 }

--- a/src/main.js
+++ b/src/main.js
@@ -38,8 +38,8 @@ const utf8 = function (str) {
     }
     return output
 }
-  
-module.exports = m => { 
+
+module.exports = function(m) { 
     const ln = m.length * 8
     const H = [1779033703, -1150833019, 1013904242, -1521486534, 1359893119, -1694144372, 528734635, 1541459225]
     const M = utf8(m);
@@ -124,6 +124,7 @@ module.exports = m => {
 
     if (fast) {
         return Buffer.from(arr).toString('hex')
-    }
-    return arr.map(i => i.toString(16).padStart(2, '0')).join('')
+	}
+
+    return arr.map(function(i) { return i.toString(16).padStart(2, '0') }).join('')
 }


### PR DESCRIPTION
When including this code with a package manager into a project and running it on internet explorer 11 the project crashes with a syntax error because the fat arrows aren't converted into classic functions. This still happens when using a polyfill package like core-js.

By replacing the fat arrows with classic functions this problem can be avoided.