### PR TITLE
Typescript definition file

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,0 +1,4 @@
+declare module 'simple-js-sha2-256' {
+	const sha: (text: string) => string
+	export default sha
+}


### PR DESCRIPTION
This file allows to import the package into a TypeScript project like this:
`import sha from 'simple-js-sha2-256'`

This definition also forces the input parameter to be a string in a TypeScript project.